### PR TITLE
allow hieradata in all stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ But if you need to customize the configuration you can see in
 [documentation](https://ansible-hiera-data.readthedocs.io/en/latest/plugins/hieradata_vars.html#ansible-collections-codeaffen-hieradata-hieradata-vars)
 you can configure the vars plugin eigther via `ansible.cfg` parameter in section `hieradata` or via environment variables.
 
-You have to keep in mind that the paths for `basedir` and `config` are relative to your inventory directory. Without any configuration you have to place
-the basedir and config as followed.
+You have to keep in mind that the paths for `basedir` and `config` are relative to your inventory or playbook directory, depending of the selected stage. Without any configuration you have to place the basedir and config as followed.
 
 ```bash
 .

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,4 +10,4 @@ config = hieradata.yml
 hash_behavior = merge
 list_behavior = replace
 load_data_for = hosts
-stage = inventory
+stage = all

--- a/plugins/module_utils/hieradata.py
+++ b/plugins/module_utils/hieradata.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import os
 import yaml
 
 from jinja2 import Template
@@ -20,17 +21,19 @@ def parse_config(entity, config):
     :return: list of paths which reflects the hierarchy
     :rtype: list
     """
-    with open(config) as fd:
-        fd_data = yaml.load(fd, Loader=SafeLoader)
+    hierarchy = None
+    if os.path.exists(config) and os.path.isfile(config):
+        with open(config) as fd:
+            fd_data = yaml.load(fd, Loader=SafeLoader)
 
-    hiera_vars = {}
-    for k, v in fd_data['hiera_vars'].items():
-        t = Template(v)
-        hiera_vars[k] = t.render(entity=entity)
+        hiera_vars = {}
+        for k, v in fd_data['hiera_vars'].items():
+            t = Template(v)
+            hiera_vars[k] = t.render(entity=entity)
 
-    hierarchy = []
-    for i, entry in enumerate(fd_data['hierarchy']):
-        t = Template(entry)
-        hierarchy.insert(i, t.render(hiera_vars))
+        hierarchy = []
+        for i, entry in enumerate(fd_data['hierarchy']):
+            t = Template(entry)
+            hierarchy.insert(i, t.render(hiera_vars))
 
     return hierarchy


### PR DESCRIPTION
Prior to this PR we only support stage `inventory`. 
We now add code to support all other stages too.
Config file and hierarchy can now also resists in playbook directory.
